### PR TITLE
Logs

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -19,6 +19,7 @@ after: # list of services that we depend on (optional)
    - service2_name
 signal: # optional section
   stop: SIGKILL # the signal sent on `stop` action. default to SIGTERM
+log: null | ring | stdout
 ``` 
 
 - `oneshot` service is not going to re-spawn when it exits.
@@ -28,6 +29,15 @@ signal: # optional section
 - If a test command is provided, the service will not consider running, unless the test command pass
 - You can override the stop signal sent to the service as shown in the example. Currently only the stop
   signal can be overwritten. More signal types might be added in the future (for example, reload).
+- the log directive can be set to one of the following values
+  - `null`: ignore all service logs (like `> /dev/null`)
+  - `ring`: the default value, which means all logs of the service is written to the kernel ring buffer. The name is service is prepended to the log line.
+  - `stdout`: print the output on zinit stdout
+
+> Note: to use `ring` inside docker make sure you add the `kmsg` device to the list of allowed devices
+```
+docker run -dt --device=/dev/kmsg:/dev/kmsg:wm zinit
+```
 
 #### Examples
 redis-init.yaml

--- a/src/manager/pm.rs
+++ b/src/manager/pm.rs
@@ -93,7 +93,6 @@ impl ProcessManager {
         let mut cmd = Command::new(&args[0]);
         let cmd = match log {
             Log::Stdout => &mut cmd,
-            Log::Null => cmd.stdout(Stdio::null()).stderr(Stdio::null()),
             Log::Ring => {
                 let awk = Command::new("sh")
                     .arg("-c")

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -28,9 +28,22 @@ impl Default for Signal {
         }
     }
 }
+#[serde(rename_all = "lowercase")]
+#[derive(Clone, Debug, Deserialize)]
+pub enum Log {
+    Null,
+    Ring,
+    Stdout,
+}
+
+impl Default for Log {
+    fn default() -> Self {
+        Log::Ring
+    }
+}
 
 #[serde(default)]
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize)]
 pub struct Service {
     /// command to run
     pub exec: String,
@@ -39,8 +52,10 @@ pub struct Service {
     pub test: String,
     #[serde(rename = "oneshot")]
     pub one_shot: bool,
+    //pub env: HashMap<String, String>,
     pub after: Vec<String>,
     pub signal: Signal,
+    pub log: Log,
 }
 
 impl Service {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -31,7 +31,6 @@ impl Default for Signal {
 #[serde(rename_all = "lowercase")]
 #[derive(Clone, Debug, Deserialize)]
 pub enum Log {
-    Null,
     Ring,
     Stdout,
 }


### PR DESCRIPTION
Support logs configuration for each service

A `log` directive in the config supports 3 values
- `null`: like directing to /dev/null
- `ring` append the service logs to the kernel ring buffer (default)
- `stdout`: print logs to stdout