### PR TITLE
Build zinit statically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,5 +3,8 @@ default: release
 docker: release
 	docker build -f docker/Dockerfile -t zinit-ubuntu:18.04 target/release
 
-release:
-	cargo build --release
+prepare:
+	rustup target  add x86_64-unknown-linux-musl
+
+release: prepare
+	cargo build --release --target=x86_64-unknown-linux-musl


### PR DESCRIPTION
This will make it easier to use it as entry point in containers