### PR TITLE
We make sure process table is locked

### DIFF
--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -169,6 +169,8 @@ impl ProcessManager {
             _ => child, // default to inherit
         };
 
+        let mut table = self.table.lock().await;
+
         let mut child = child
             .group_spawn()
             .context("failed to spawn command")?
@@ -190,7 +192,6 @@ impl ProcessManager {
 
         let id = child.id();
 
-        let mut table = self.table.lock().await;
         let pid = Pid::from_raw(id as i32);
         table.insert(pid, tx);
 


### PR DESCRIPTION
The locking must be done before spawning
to prevent reaping of the pid if the process
exited immediately before it's actually
in the process table