### PR TITLE
Support log snapshot

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -146,7 +146,10 @@ pub async fn kill(socket: &str, name: &str, signal: &str) -> Result<()> {
     client.kill(name, signal).await?;
     Ok(())
 }
-pub async fn logs(socket: &str, filter: Option<&str>) -> Result<()> {
+pub async fn logs(socket: &str, filter: Option<&str>, follow: bool) -> Result<()> {
     let client = api::Client::new(socket);
-    client.logs(tokio::io::stdout(), filter).await
+    if let Some(filter) = filter {
+        client.status(filter).await?;
+    }
+    client.logs(tokio::io::stdout(), filter, follow).await
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,6 +108,13 @@ async fn main() -> Result<()> {
         .subcommand(
             SubCommand::with_name("log")
                 .arg(
+                    Arg::with_name("snapshot")
+                        .short("s")
+                        .long("snapshot")
+                        .required(false)
+                        .help("if set log prints current buffer without following")
+                    )
+                .arg(
                     Arg::with_name("filter")
                         .value_name("FILTER")
                         .required(false)
@@ -171,14 +178,21 @@ async fn main() -> Result<()> {
             )
             .await
         }
-        ("log", Some(matches)) => app::logs(socket, matches.value_of("filter")).await,
+        ("log", Some(matches)) => {
+            app::logs(
+                socket,
+                matches.value_of("filter"),
+                !matches.is_present("snapshot"),
+            )
+            .await
+        }
         _ => app::list(socket).await, // default command
     };
 
     match result {
         Ok(_) => Ok(()),
         Err(e) => {
-            eprintln!("{}", e);
+            eprintln!("{:#}", e);
             std::process::exit(1);
         }
     }

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -141,8 +141,8 @@ impl ProcessManager {
         });
     }
 
-    pub async fn stream(&self) -> Result<Logs> {
-        self.ring.stream().await
+    pub async fn stream(&self, follow: bool) -> Logs {
+        self.ring.stream(follow).await
     }
 
     pub fn signal(&self, pid: Pid, sig: signal::Signal) -> Result<()> {

--- a/src/zinit/config.rs
+++ b/src/zinit/config.rs
@@ -23,19 +23,15 @@ impl Default for Signal {
     }
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Default, Clone, Debug, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Log {
     None,
+    #[default]
     Ring,
     Stdout,
 }
 
-impl Default for Log {
-    fn default() -> Self {
-        Log::Ring
-    }
-}
 fn default_shutdown_timeout_fn() -> u64 {
     DEFAULT_SHUTDOWN_TIMEOUT
 }

--- a/src/zinit/mod.rs
+++ b/src/zinit/mod.rs
@@ -194,8 +194,8 @@ impl ZInit {
         let _ = self.shutdown().await;
     }
 
-    pub async fn logs(&self) -> Result<Logs> {
-        self.pm.stream().await
+    pub async fn logs(&self, follow: bool) -> Logs {
+        self.pm.stream(follow).await
     }
 
     pub async fn monitor<S: Into<String>>(&self, name: S, service: config::Service) -> Result<()> {
@@ -668,7 +668,7 @@ impl ZInit {
             drop(service);
             if config.one_shot {
                 // we don't need to restart the service anymore
-                let _ = self.notify.notify_waiters();
+                self.notify.notify_waiters();
                 break;
             }
             // we trying again in 2 seconds


### PR DESCRIPTION
The log snapshot is basically printing a copy of the current logs buffer (then terminate) instead of the default `follow` behavior.

by providing a `-s` flag to the log command line, the logs will print the current buffer, then exits.

running `zinit log` will still automatically follow the logs as the default behavior