### PR TITLE
File logs

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -68,6 +68,8 @@ exec: redis-server --port 7777
 test: redis-cli -p 7777 PING
 after:
   - redis-init
+log: file
+log_file: redis_log.txt
 ```
 
 redis-after.yaml

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -27,7 +27,8 @@ after: # list of services that we depend on (optional)
   - service2_name
 signal: # optional section
   stop: SIGKILL # the signal sent on `stop` action. default to SIGTERM
-log: null | ring | stdout
+log: null | ring | stdout | file
+log_file: "/path/to/logfile" # required that `log` is set to `file`
 env:
   KEY: VALUE
 ```

--- a/src/zinit/config.rs
+++ b/src/zinit/config.rs
@@ -30,6 +30,7 @@ pub enum Log {
     #[default]
     Ring,
     Stdout,
+    File,
 }
 
 fn default_shutdown_timeout_fn() -> u64 {
@@ -50,6 +51,7 @@ pub struct Service {
     pub after: Vec<String>,
     pub signal: Signal,
     pub log: Log,
+    pub log_file: Option<String>,
     pub env: HashMap<String, String>,
     pub dir: String,
 }
@@ -63,6 +65,13 @@ impl Service {
         }
 
         Signal::from_str(&self.signal.stop.to_uppercase())?;
+
+        // Validate `log_file` when `log` is `File`
+        if let Log::File = self.log {
+            if self.log_file.is_none() {
+                bail!("log_file must be specified when log is set to 'file'");
+            }
+        }
 
         Ok(())
     }

--- a/src/zinit/mod.rs
+++ b/src/zinit/mod.rs
@@ -506,6 +506,15 @@ impl ZInit {
             config::Log::None => Log::None,
             config::Log::Stdout => Log::Stdout,
             config::Log::Ring => Log::Ring(format!("{}/test", name.as_ref())),
+            config::Log::File => {
+                if let Some(log_file) = &cfg.log_file {
+                    Log::File(log_file.clone())
+                } else {
+                    error!("log_file is not specified for service '{}'", name.as_ref());
+
+                    Log::None
+                }
+            }
         };
 
         let test = self
@@ -596,6 +605,15 @@ impl ZInit {
                 config::Log::None => Log::None,
                 config::Log::Stdout => Log::Stdout,
                 config::Log::Ring => Log::Ring(name.clone()),
+                config::Log::File => {
+                    if let Some(log_file) = &config.log_file {
+                        Log::File(log_file.clone())
+                    } else {
+                        error!("log_file is not specified for service '{}'", name);
+
+                        Log::None
+                    }
+                }
             };
 
             let mut service = input.write().await;


### PR DESCRIPTION
The logs of services can now also be written to file by using the `log: file` and `log_file: path/to/logfile` flags in the `<service>.yaml`.

Example: `redis.yaml`

```
exec: redis-server --port 7777
test: redis-cli -p 7777 PING
after:
  - redis-init
log: file
log_file: redis_log.txt
```


Closes #68