### PR TITLE
docs: Improve and expand Zinit API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Zinit is a service manager designed to be simple, lightweight, and reliable for 
 
 Comprehensive documentation is available in the [docs](docs) directory:
 
-- [Command Line Interface](docs/readme.md)
+- [Command Line Interface](docs/README.md)
 - [Implementation Details](docs/implementation.md)
 - [API Protocol](docs/protocol.md)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,9 @@ The documentation is organized into these main sections:
 - **Configuration**: Service file format and examples
 - **Usage**: Command reference and workflows
 - **Architecture**: System design and implementation
-- **API**: Protocol for communicating with Zinit
+- **API**: Protocols for communicating with Zinit
+  - [Line-based Protocol](api/protocol.md)
+  - [JSON-RPC API (OpenRPC)](api/openrpc.md)
 
 ## Key Concepts
 
@@ -63,4 +65,3 @@ For more detailed documentation, start with:
 
 The older documentation is still available:
 - [Legacy Implementation Details](implementation.md)
-- [Legacy Protocol Documentation](protocol.md)

--- a/docs/api/openrpc.md
+++ b/docs/api/openrpc.md
@@ -1,0 +1,129 @@
+# Zinit JSON-RPC API Documentation
+
+This document describes the JSON-RPC 2.0 API for Zinit. The API allows external applications to control and query Zinit services using the JSON-RPC 2.0 protocol.
+
+> **Note:** The JSON-RPC API is currently in development and may not be fully functional in all Zinit versions. For production use, it's recommended to use the [line-based protocol](protocol.md) which is stable and well-tested.
+
+## OpenRPC Specification
+
+The OpenRPC specification for Zinit's API is exists in the [openrpc.json](../../openrpc.json) file. You can copy this JSON and paste it into the [OpenRPC Playground](https://playground.open-rpc.org/) to explore the API interactively.
+
+
+## Using the OpenRPC Playground
+
+To explore the Zinit JSON-RPC API interactively:
+
+1. Visit [OpenRPC Playground](https://playground.open-rpc.org/)
+2. Copy the JSON specification above
+3. Paste it into the editor on the left side of the playground
+4. Use the interactive documentation on the right side to explore the API
+
+## JSON-RPC 2.0 Protocol
+
+Zinit implements the JSON-RPC 2.0 protocol as defined in the [JSON-RPC 2.0 Specification](https://www.jsonrpc.org/specification).
+
+### Request Format
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "service.list",
+  "params": {}
+}
+```
+
+Where:
+- `jsonrpc`: Must be exactly "2.0"
+- `id`: A unique identifier for the request (can be a number, string, or null)
+- `method`: The name of the method to call
+- `params`: An object containing the parameters for the method (can be omitted for methods that don't require parameters)
+
+### Response Format
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {}
+}
+```
+
+Or, in case of an error:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "error": {
+    "code": -32000,
+    "message": "Service not found",
+    "data": "service name \"unknown\" unknown"
+  }
+}
+```
+
+Where:
+- `jsonrpc`: Always "2.0"
+- `id`: The same id as in the request
+- `result`: The result of the method call (only present if the call was successful)
+- `error`: Error information (only present if the call failed)
+  - `code`: A number indicating the error type
+  - `message`: A short description of the error
+  - `data`: Additional information about the error (optional)
+
+## Client Example: Using Python
+
+A simple Python client for the JSON-RPC API (note that this may not work with all Zinit versions):
+
+```python
+import socket
+import json
+
+def zinit_jsonrpc(method, params=None):
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.connect("/var/run/zinit.sock")
+    
+    request = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": method
+    }
+    
+    if params:
+        request["params"] = params
+    
+    # Send the JSON-RPC request without a newline
+    sock.send(json.dumps(request).encode())
+    
+    response = sock.recv(4096).decode()
+    sock.close()
+    
+    return json.loads(response)
+
+# Usage examples
+services = zinit_jsonrpc("service.list")
+redis_status = zinit_jsonrpc("service.status", {"name": "redis"})
+start_result = zinit_jsonrpc("service.start", {"name": "nginx"})
+```
+
+## Error Codes
+
+Zinit uses standard JSON-RPC 2.0 error codes as well as custom error codes:
+
+### Standard JSON-RPC 2.0 Error Codes
+
+- `-32600`: Invalid Request - The JSON sent is not a valid Request object
+- `-32601`: Method not found - The method does not exist / is not available
+- `-32602`: Invalid params - Invalid method parameter(s)
+- `-32603`: Internal error - Internal JSON-RPC error
+
+### Custom Zinit Error Codes
+
+- `-32000`: Service not found - The requested service does not exist
+- `-32001`: Service already monitored - The service is already being monitored
+- `-32002`: Service is up - The service is currently running
+- `-32003`: Service is down - The service is currently not running
+- `-32004`: Invalid signal - The provided signal is invalid
+- `-32005`: Config error - Error in service configuration
+- `-32006`: Shutting down - The system is already shutting down

--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -1,10 +1,12 @@
-# Zinit API Protocol
+# Zinit Line-Based API Protocol
 
-This document describes the wire protocol used to communicate with a running Zinit instance. The protocol allows external applications to control and query Zinit services.
+This document describes the line-based wire protocol used to communicate with a running Zinit instance. The protocol allows external applications to control and query Zinit services.
+
+> **Note:** Zinit also supports a JSON-RPC 2.0 API. For documentation on the JSON-RPC API, see [JSON-RPC API (OpenRPC)](openrpc.md).
 
 ## Protocol Overview
 
-Zinit uses a simple line-based text protocol over a Unix domain socket. The protocol follows a request-response pattern similar to HTTP 1.0:
+Zinit supports a simple line-based text protocol over a Unix domain socket. The protocol follows a request-response pattern similar to HTTP 1.0:
 
 1. Client connects to the Unix socket
 2. Client sends a command (terminated by newline)

--- a/docs/usage/commands.md
+++ b/docs/usage/commands.md
@@ -296,9 +296,11 @@ zinit init --container -c /app/services/
 zinit monitor app
 ```
 
-### Manual Service Control with nc
+### Manual Service Control
 
-Since Zinit uses a simple line protocol, you can interact with it using netcat:
+#### Using Line-Based Protocol with nc
+
+Zinit supports a simple line-based protocol that you can interact with using netcat:
 
 ```bash
 # List services

--- a/openrpc.json
+++ b/openrpc.json
@@ -1,0 +1,498 @@
+{
+  "openrpc": "1.2.6",
+  "info": {
+    "version": "1.0.0",
+    "title": "Zinit JSON-RPC API",
+    "description": "JSON-RPC 2.0 API for controlling and querying Zinit services",
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "servers": [
+    {
+      "name": "Unix Socket",
+      "url": "unix:///var/run/zinit.sock"
+    }
+  ],
+  "methods": [
+    {
+      "name": "service.list",
+      "description": "Lists all services managed by Zinit",
+      "params": [],
+      "result": {
+        "name": "ServiceList",
+        "description": "A map of service names to their current states",
+        "schema": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "description": "Service state (Running, Success, Error, etc.)"
+          }
+        }
+      },
+      "examples": [
+        {
+          "name": "List all services",
+          "params": [],
+          "result": {
+            "name": "ServiceListResult",
+            "value": {
+              "service1": "Running",
+              "service2": "Success",
+              "service3": "Error"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "service.status",
+      "description": "Shows detailed status information for a specific service",
+      "params": [
+        {
+          "name": "name",
+          "description": "The name of the service",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "result": {
+        "name": "ServiceStatus",
+        "description": "Detailed status information for the service",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Service name"
+            },
+            "pid": {
+              "type": "integer",
+              "description": "Process ID of the running service (if running)"
+            },
+            "state": {
+              "type": "string",
+              "description": "Current state of the service (Running, Success, Error, etc.)"
+            },
+            "target": {
+              "type": "string",
+              "description": "Target state of the service (Up, Down)"
+            },
+            "after": {
+              "type": "object",
+              "description": "Dependencies of the service and their states",
+              "additionalProperties": {
+                "type": "string",
+                "description": "State of the dependency"
+              }
+            }
+          }
+        }
+      },
+      "examples": [
+        {
+          "name": "Get status of redis service",
+          "params": [
+            {
+              "name": "name",
+              "value": "redis"
+            }
+          ],
+          "result": {
+            "name": "ServiceStatusResult",
+            "value": {
+              "name": "redis",
+              "pid": 1234,
+              "state": "Running",
+              "target": "Up",
+              "after": {
+                "dependency1": "Success",
+                "dependency2": "Running"
+              }
+            }
+          }
+        }
+      ],
+      "errors": [
+        {
+          "code": -32000,
+          "message": "Service not found",
+          "data": "service name \"unknown\" unknown"
+        }
+      ]
+    },
+    {
+      "name": "service.start",
+      "description": "Starts a service",
+      "params": [
+        {
+          "name": "name",
+          "description": "The name of the service to start",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "result": {
+        "name": "StartResult",
+        "description": "Result of the start operation",
+        "schema": {
+          "type": "null"
+        }
+      },
+      "examples": [
+        {
+          "name": "Start redis service",
+          "params": [
+            {
+              "name": "name",
+              "value": "redis"
+            }
+          ],
+          "result": {
+            "name": "StartResult",
+            "value": null
+          }
+        }
+      ],
+      "errors": [
+        {
+          "code": -32000,
+          "message": "Service not found",
+          "data": "service name \"unknown\" unknown"
+        }
+      ]
+    },
+    {
+      "name": "service.stop",
+      "description": "Stops a service",
+      "params": [
+        {
+          "name": "name",
+          "description": "The name of the service to stop",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "result": {
+        "name": "StopResult",
+        "description": "Result of the stop operation",
+        "schema": {
+          "type": "null"
+        }
+      },
+      "examples": [
+        {
+          "name": "Stop redis service",
+          "params": [
+            {
+              "name": "name",
+              "value": "redis"
+            }
+          ],
+          "result": {
+            "name": "StopResult",
+            "value": null
+          }
+        }
+      ],
+      "errors": [
+        {
+          "code": -32000,
+          "message": "Service not found",
+          "data": "service name \"unknown\" unknown"
+        },
+        {
+          "code": -32003,
+          "message": "Service is down",
+          "data": "service \"redis\" is down"
+        }
+      ]
+    },
+    {
+      "name": "service.monitor",
+      "description": "Starts monitoring a service. The service configuration is loaded from the config directory.",
+      "params": [
+        {
+          "name": "name",
+          "description": "The name of the service to monitor",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "result": {
+        "name": "MonitorResult",
+        "description": "Result of the monitor operation",
+        "schema": {
+          "type": "null"
+        }
+      },
+      "examples": [
+        {
+          "name": "Monitor redis service",
+          "params": [
+            {
+              "name": "name",
+              "value": "redis"
+            }
+          ],
+          "result": {
+            "name": "MonitorResult",
+            "value": null
+          }
+        }
+      ],
+      "errors": [
+        {
+          "code": -32001,
+          "message": "Service already monitored",
+          "data": "service \"redis\" already monitored"
+        },
+        {
+          "code": -32005,
+          "message": "Config error",
+          "data": "failed to load service configuration"
+        }
+      ]
+    },
+    {
+      "name": "service.forget",
+      "description": "Stops monitoring a service. You can only forget a stopped service.",
+      "params": [
+        {
+          "name": "name",
+          "description": "The name of the service to forget",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "result": {
+        "name": "ForgetResult",
+        "description": "Result of the forget operation",
+        "schema": {
+          "type": "null"
+        }
+      },
+      "examples": [
+        {
+          "name": "Forget redis service",
+          "params": [
+            {
+              "name": "name",
+              "value": "redis"
+            }
+          ],
+          "result": {
+            "name": "ForgetResult",
+            "value": null
+          }
+        }
+      ],
+      "errors": [
+        {
+          "code": -32000,
+          "message": "Service not found",
+          "data": "service name \"unknown\" unknown"
+        },
+        {
+          "code": -32002,
+          "message": "Service is up",
+          "data": "service \"redis\" is up"
+        }
+      ]
+    },
+    {
+      "name": "service.kill",
+      "description": "Sends a signal to a running service",
+      "params": [
+        {
+          "name": "name",
+          "description": "The name of the service to send the signal to",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "signal",
+          "description": "The signal to send (e.g., SIGTERM, SIGKILL)",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "result": {
+        "name": "KillResult",
+        "description": "Result of the kill operation",
+        "schema": {
+          "type": "null"
+        }
+      },
+      "examples": [
+        {
+          "name": "Send SIGTERM to redis service",
+          "params": [
+            {
+              "name": "name",
+              "value": "redis"
+            },
+            {
+              "name": "signal",
+              "value": "SIGTERM"
+            }
+          ],
+          "result": {
+            "name": "KillResult",
+            "value": null
+          }
+        }
+      ],
+      "errors": [
+        {
+          "code": -32000,
+          "message": "Service not found",
+          "data": "service name \"unknown\" unknown"
+        },
+        {
+          "code": -32003,
+          "message": "Service is down",
+          "data": "service \"redis\" is down"
+        },
+        {
+          "code": -32004,
+          "message": "Invalid signal",
+          "data": "invalid signal: INVALID"
+        }
+      ]
+    },
+    {
+      "name": "system.shutdown",
+      "description": "Stops all services and powers off the system",
+      "params": [],
+      "result": {
+        "name": "ShutdownResult",
+        "description": "Result of the shutdown operation",
+        "schema": {
+          "type": "null"
+        }
+      },
+      "examples": [
+        {
+          "name": "Shutdown the system",
+          "params": [],
+          "result": {
+            "name": "ShutdownResult",
+            "value": null
+          }
+        }
+      ],
+      "errors": [
+        {
+          "code": -32006,
+          "message": "Shutting down",
+          "data": "system is already shutting down"
+        }
+      ]
+    },
+    {
+      "name": "system.reboot",
+      "description": "Stops all services and reboots the system",
+      "params": [],
+      "result": {
+        "name": "RebootResult",
+        "description": "Result of the reboot operation",
+        "schema": {
+          "type": "null"
+        }
+      },
+      "examples": [
+        {
+          "name": "Reboot the system",
+          "params": [],
+          "result": {
+            "name": "RebootResult",
+            "value": null
+          }
+        }
+      ],
+      "errors": [
+        {
+          "code": -32006,
+          "message": "Shutting down",
+          "data": "system is already shutting down"
+        }
+      ]
+    }
+  ],
+  "components": {
+    "contentDescriptors": {},
+    "schemas": {}
+  },
+  "errors": [
+    {
+      "code": -32600,
+      "message": "Invalid Request",
+      "description": "The JSON sent is not a valid Request object"
+    },
+    {
+      "code": -32601,
+      "message": "Method not found",
+      "description": "The method does not exist / is not available"
+    },
+    {
+      "code": -32602,
+      "message": "Invalid params",
+      "description": "Invalid method parameter(s)"
+    },
+    {
+      "code": -32603,
+      "message": "Internal error",
+      "description": "Internal JSON-RPC error"
+    },
+    {
+      "code": -32000,
+      "message": "Service not found",
+      "description": "The requested service does not exist"
+    },
+    {
+      "code": -32001,
+      "message": "Service already monitored",
+      "description": "The service is already being monitored"
+    },
+    {
+      "code": -32002,
+      "message": "Service is up",
+      "description": "The service is currently running"
+    },
+    {
+      "code": -32003,
+      "message": "Service is down",
+      "description": "The service is currently not running"
+    },
+    {
+      "code": -32004,
+      "message": "Invalid signal",
+      "description": "The provided signal is invalid"
+    },
+    {
+      "code": -32005,
+      "message": "Config error",
+      "description": "Error in service configuration"
+    },
+    {
+      "code": -32006,
+      "message": "Shutting down",
+      "description": "The system is shutting down"
+    }
+  ]
+}

--- a/src/app/api.rs
+++ b/src/app/api.rs
@@ -512,7 +512,6 @@ impl Api {
             Err(err) => {
                 error!("failed to read request: {}", err);
                 let _ = stream.write_all("bad request".as_ref()).await;
-                return;
             }
         }
     }
@@ -722,7 +721,7 @@ impl Client {
         let data = data.trim_end();
 
         // Parse the JSON-RPC response
-        let response: JsonRpcResponse = encoder::from_str(&data)?;
+        let response: JsonRpcResponse = encoder::from_str(data)?;
 
         // Handle the response
         if let Some(error) = response.error {
@@ -764,7 +763,7 @@ impl Client {
         let data = String::from_utf8(buffer)?;
         let data = data.trim_end();
 
-        let response: Response = encoder::from_str(&data)?;
+        let response: Response = encoder::from_str(data)?;
 
         match response.state {
             State::Ok => Ok(response.body),

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -47,10 +47,7 @@ type Handler = oneshot::Sender<WaitStatus>;
 
 impl Process {
     pub fn new<S: Into<String>>(cmd: S, cwd: S, env: Option<HashMap<String, String>>) -> Process {
-        let env = match env {
-            None => HashMap::new(),
-            Some(env) => env,
-        };
+        let env = env.unwrap_or_default();
 
         Process {
             env,

--- a/src/zinit/lifecycle.rs
+++ b/src/zinit/lifecycle.rs
@@ -97,7 +97,7 @@ impl LifecycleManager {
         let service = Arc::new(RwLock::new(ZInitService::new(service, State::Unknown)));
         services.insert(name.clone(), Arc::clone(&service));
 
-        let lifecycle = self.clone();
+        let lifecycle = self.clone_lifecycle();
         debug!("service '{}' monitored", name);
         tokio::spawn(lifecycle.watch_service(name, service));
 
@@ -132,7 +132,7 @@ impl LifecycleManager {
             .get(name.as_ref())
             .ok_or_else(|| ZInitError::unknown_service(name.as_ref()))?;
 
-        let lifecycle = self.clone();
+        let lifecycle = self.clone_lifecycle();
         tokio::spawn(lifecycle.watch_service(name.as_ref().into(), Arc::clone(service)));
 
         Ok(())
@@ -284,7 +284,7 @@ impl LifecycleManager {
                     }
 
                     let shutdown_timeout = shutdown_timeouts.remove(child);
-                    let lifecycle = self.clone();
+                    let lifecycle = self.clone_lifecycle();
                     tokio::spawn(Self::kill_wait(
                         lifecycle,
                         child.to_string(),
@@ -551,7 +551,7 @@ impl LifecycleManager {
 
             let mut handler = None;
             if !config.one_shot {
-                let lifecycle = self.clone();
+                let lifecycle = self.clone_lifecycle();
                 handler = Some(tokio::spawn(
                     lifecycle.test_loop(name.clone(), config.clone()),
                 ));
@@ -595,7 +595,7 @@ impl LifecycleManager {
     }
 
     /// Clone the lifecycle manager
-    pub fn clone(&self) -> Self {
+    pub fn clone_lifecycle(&self) -> Self {
         Self {
             pm: self.pm.clone(),
             services: Arc::clone(&self.services),

--- a/src/zinit/mod.rs
+++ b/src/zinit/mod.rs
@@ -40,7 +40,7 @@ impl ZInit {
     pub fn serve(&self) {
         self.lifecycle.process_manager().start();
         if self.lifecycle.is_container_mode() {
-            let lifecycle = self.lifecycle.clone();
+            let lifecycle = self.lifecycle.clone_lifecycle();
             tokio::spawn(async move {
                 use tokio::signal::unix;
 

--- a/src/zinit/ord.rs
+++ b/src/zinit/ord.rs
@@ -16,10 +16,7 @@ pub async fn service_dependency_order(services: Arc<RwLock<ServiceTable>>) -> Pr
     for (name, service) in table.iter() {
         let service = service.read().await;
         for child in service.service.after.iter() {
-            children
-                .entry(name.into())
-                .or_default()
-                .push(child.into());
+            children.entry(name.into()).or_default().push(child.into());
             *indegree.entry(child.into()).or_insert(0) += 1;
         }
     }

--- a/src/zinit/ord.rs
+++ b/src/zinit/ord.rs
@@ -18,7 +18,7 @@ pub async fn service_dependency_order(services: Arc<RwLock<ServiceTable>>) -> Pr
         for child in service.service.after.iter() {
             children
                 .entry(name.into())
-                .or_insert_with(Vec::new)
+                .or_default()
                 .push(child.into());
             *indegree.entry(child.into()).or_insert(0) += 1;
         }


### PR DESCRIPTION
### Changes

- Added detailed documentation for the new JSON-RPC API, including OpenRPC specification, request/response formats, client example, and error codes.
- Updated documentation for the line-based API to clarify its role relative to the JSON-RPC API.
- Corrected a link in the main README.md file.
- Expanded the API documentation to include separate sections for the line-based protocol and the JSON-RPC API.