### PR TITLE
Revert zinit/rfs URL rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ZOS Init [![Rust](https://github.com/threefoldtech/zos_zinit/actions/workflows/rust.yml/badge.svg)](https://github.com/threefoldtech/zos_zinit/actions/workflows/rust.yml)
+# ZOS Init [![Rust](https://github.com/threefoldtech/zinit/actions/workflows/rust.yml/badge.svg)](https://github.com/threefoldtech/zinit/actions/workflows/rust.yml)
 
 ZOS Init is a lightweight PID 1 replacement inspired by runit, written in Rust using Tokio for async I/O. It manages service startup, supervision, and lifecycle, ensuring configured services remain running and handling dependencies through a simple declarative interface.
 
@@ -35,10 +35,10 @@ This repository is owned and maintained by TF-Tech NV, a Belgian company respons
 ## Installation
 
 ```bash
-curl https://raw.githubusercontent.com/threefoldtech/zos_zinit/refs/heads/master/install.sh | bash
+curl https://raw.githubusercontent.com/threefoldtech/zinit/refs/heads/master/install.sh | bash
 
 # to install & run
-curl https://raw.githubusercontent.com/threefoldtech/zos_zinit/refs/heads/master/install_run.sh | bash
+curl https://raw.githubusercontent.com/threefoldtech/zinit/refs/heads/master/install_run.sh | bash
 ```
 
 Click [here](docs/installation.md) for more information on how to install ZOS Init.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -15,7 +15,7 @@ If pre-built binaries are available for your system, you can install them direct
 
 ```bash
 # Download the binary (replace with actual URL)
-wget https://github.com/threefoldtech/zos_zinit/releases/download/vX.Y.Z/zinit-x86_64-unknown-linux-musl
+wget https://github.com/threefoldtech/zinit/releases/download/vX.Y.Z/zinit-x86_64-unknown-linux-musl
 
 # Make it executable
 chmod +x zinit-x86_64-unknown-linux-musl
@@ -69,7 +69,7 @@ apk add build-base
 1. Clone the repository:
 
 ```bash
-git clone https://github.com/threefoldtech/zos_zinit.git
+git clone https://github.com/threefoldtech/zinit.git
 cd zinit
 ```
 

--- a/install.sh
+++ b/install.sh
@@ -9,12 +9,12 @@ NC='\033[0m' # No Color
 
 echo -e "${GREEN}stop zinit...${NC}"
 rm -f /tmp/stop.sh
-curl -fsSL https://raw.githubusercontent.com/threefoldtech/zos_zinit/refs/heads/master/stop.sh > /tmp/stop.sh
+curl -fsSL https://raw.githubusercontent.com/threefoldtech/zinit/refs/heads/master/stop.sh > /tmp/stop.sh
 bash /tmp/stop.sh
 
 
 # GitHub repository information
-GITHUB_REPO="threefoldtech/zos_zinit"
+GITHUB_REPO="threefoldtech/zinit"
 
 # Get the latest version from GitHub API
 echo -e "${YELLOW}Fetching latest version information...${NC}"

--- a/install_run.sh
+++ b/install_run.sh
@@ -19,11 +19,11 @@ is_zinit_running() {
 echo -e "${GREEN}Starting zinit installation and setup...${NC}"
 # Download and execute install.sh
 echo -e "${YELLOW}Downloading and executing install.sh...${NC}"
-curl -fsSL https://raw.githubusercontent.com/threefoldtech/zos_zinit/refs/heads/master/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/threefoldtech/zinit/refs/heads/master/install.sh | bash
 
 echo -e "${GREEN}install zinit...${NC}"
 rm -f /tmp/install.sh
-curl -fsSL https://raw.githubusercontent.com/threefoldtech/zos_zinit/refs/heads/master/install.sh > /tmp/install.sh
+curl -fsSL https://raw.githubusercontent.com/threefoldtech/zinit/refs/heads/master/install.sh > /tmp/install.sh
 bash /tmp/install.sh
 
 

--- a/release_zinit.sh
+++ b/release_zinit.sh
@@ -97,5 +97,5 @@ echo "🚀 Pushing tag to trigger release..."
 git push origin "$new_version"
 
 echo "✅ Release $new_version has been triggered!"
-echo "🔗 Check the release at: https://github.com/threefoldtech/zos_zinit/releases"
-echo "🔗 Monitor the build at: https://github.com/threefoldtech/zos_zinit/actions"
+echo "🔗 Check the release at: https://github.com/threefoldtech/zinit/releases"
+echo "🔗 Monitor the build at: https://github.com/threefoldtech/zinit/actions"


### PR DESCRIPTION
The zinit and rfs repos were renamed back to their original names. Revert threefoldtech/zos_zinit -> threefoldtech/zinit and threefoldtech/zos_rfs -> threefoldtech/rfs. Other renames (zos_config / zos_sdk_go / zos_initramfs) are left intact.